### PR TITLE
Update draft-ietf-quic-tls.md

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -222,7 +222,7 @@ shared secrets that cannot be controlled by either participating peer.
 TLS 1.3 provides two basic handshake modes of interest to QUIC:
 
  * A full 1-RTT handshake in which the client is able to send application data
-   after one round trip and the server immediately after receiving the first
+   after one round trip and the server immediately responds after receiving the first
    handshake message from the client.
 
  * A 0-RTT handshake in which the client uses information it has previously


### PR DESCRIPTION
The original sentence "the server immediately after receiving the first handshake message from the client" lacks a predicate, "responds" may fit.